### PR TITLE
closes #13, Mapping links to name

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": false,
+  "endOfLine": "lf",
+  "bracketSpacing": true,
+  "arrowParens": "always"
+}

--- a/src/App.js
+++ b/src/App.js
@@ -28,6 +28,7 @@ import {
   getFacetFields,
 } from "./config/config-helper";
 import logo from "./btc.png";
+import CustomMultiCheckboxFacet from "./components/CustomMultiCheckboxFacet";
 
 const htmlToReactParser = new Parser();
 const { hostIdentifier, searchKey, endpointBase, engineName } = getConfig();
@@ -120,7 +121,7 @@ export default function App() {
                     <div>
                       {wasSearched}
                       {getFacetFields().map((field) => (
-                        <Facet key={field} field={field} label={field} />
+                        <Facet key={field} field={field} label={field} view={CustomMultiCheckboxFacet} />
                       ))}
                     </div>
                   }

--- a/src/components/CustomMultiCheckboxFacet.js
+++ b/src/components/CustomMultiCheckboxFacet.js
@@ -1,7 +1,7 @@
 import React from "react";
 // import { FacetViewProps } from "./types";
 // import type { FieldValue } from "@elastic/search-ui";
-import mapping from "../config/mapping.json"
+import mapping from "../config/mapping.json";
 
 function CustomMultiCheckboxFacet({
   className,
@@ -13,34 +13,39 @@ function CustomMultiCheckboxFacet({
   showMore,
   showSearch,
   onSearch,
-  searchPlaceholder
+  searchPlaceholder,
 }) {
+  // This function was modified to add the mapping of names to links using mapping?.labels[filterValue]
+  function getFilterValueDisplay(filterValue) {
+    if (filterValue === undefined || filterValue === null) {
+      return "";
+    }
+    if (Object.prototype.hasOwnProperty.call(filterValue, "name")) {
+      return filterValue.name;
+    }
+    if (mapping?.labels[filterValue]) {
+      return mapping?.labels[filterValue];
+    }
+    return String(filterValue);
+  }
 
-    function getFilterValueDisplay(filterValue) {
-        if (filterValue === undefined || filterValue === null)
-            return "";
-        if (Object.prototype.hasOwnProperty.call(filterValue, "name"))
-            return filterValue.name;
-        if (mapping?.labels[filterValue]) {
-            return mapping?.labels[filterValue]
-        }
-        return String(filterValue);
+  function getNewClassName(newClassName) {
+    if (!Array.isArray(newClassName)) return newClassName;
+    return newClassName.filter((name) => name).join(" ");
+  }
+  function appendClassName(baseClassName, newClassName) {
+    if (!newClassName) {
+      return (
+        (Array.isArray(baseClassName)
+          ? baseClassName.join(" ")
+          : baseClassName) || ""
+      );
     }
-
-    function getNewClassName(newClassName) {
-        if (!Array.isArray(newClassName))
-            return newClassName;
-        return newClassName.filter((name) => name).join(" ");
+    if (!baseClassName) {
+      return getNewClassName(newClassName) || "";
     }
-    function appendClassName(baseClassName, newClassName) {
-        if (!newClassName)
-            return ((Array.isArray(baseClassName)
-                ? baseClassName.join(" ")
-                : baseClassName) || "");
-        if (!baseClassName)
-            return getNewClassName(newClassName) || "";
-        return `${baseClassName} ${getNewClassName(newClassName)}`;
-    }
+    return `${baseClassName} ${getNewClassName(newClassName)}`;
+  }
   return (
     <fieldset className={appendClassName("sui-facet", className)}>
       <legend className="sui-facet__title">{label}</legend>
@@ -60,8 +65,7 @@ function CustomMultiCheckboxFacet({
 
       <div className="sui-multi-checkbox-facet">
         {options.length < 1 && <div>No matching options</div>}
-        {options.map((option) => {
-            console.log(option)
+        {options?.map((option) => {
           const checked = option.selected;
           const value = option.value;
           return (

--- a/src/components/CustomMultiCheckboxFacet.js
+++ b/src/components/CustomMultiCheckboxFacet.js
@@ -1,0 +1,112 @@
+import React from "react";
+// import { FacetViewProps } from "./types";
+// import type { FieldValue } from "@elastic/search-ui";
+import mapping from "../config/mapping.json"
+
+function CustomMultiCheckboxFacet({
+  className,
+  label,
+  onMoreClick,
+  onRemove,
+  onSelect,
+  options,
+  showMore,
+  showSearch,
+  onSearch,
+  searchPlaceholder
+}) {
+
+    function getFilterValueDisplay(filterValue) {
+        if (filterValue === undefined || filterValue === null)
+            return "";
+        if (Object.prototype.hasOwnProperty.call(filterValue, "name"))
+            return filterValue.name;
+        if (mapping?.labels[filterValue]) {
+            return mapping?.labels[filterValue]
+        }
+        return String(filterValue);
+    }
+
+    function getNewClassName(newClassName) {
+        if (!Array.isArray(newClassName))
+            return newClassName;
+        return newClassName.filter((name) => name).join(" ");
+    }
+    function appendClassName(baseClassName, newClassName) {
+        if (!newClassName)
+            return ((Array.isArray(baseClassName)
+                ? baseClassName.join(" ")
+                : baseClassName) || "");
+        if (!baseClassName)
+            return getNewClassName(newClassName) || "";
+        return `${baseClassName} ${getNewClassName(newClassName)}`;
+    }
+  return (
+    <fieldset className={appendClassName("sui-facet", className)}>
+      <legend className="sui-facet__title">{label}</legend>
+
+      {showSearch && (
+        <div className="sui-facet-search">
+          <input
+            className="sui-facet-search__text-input"
+            type="search"
+            placeholder={searchPlaceholder || "Search"}
+            onChange={(e) => {
+              onSearch(e.target.value);
+            }}
+          />
+        </div>
+      )}
+
+      <div className="sui-multi-checkbox-facet">
+        {options.length < 1 && <div>No matching options</div>}
+        {options.map((option) => {
+            console.log(option)
+          const checked = option.selected;
+          const value = option.value;
+          return (
+            <label
+              key={`${getFilterValueDisplay(option.value)}`}
+              htmlFor={`example_facet_${label}${getFilterValueDisplay(
+                option.value
+              )}`}
+              className="sui-multi-checkbox-facet__option-label"
+            >
+              <div className="sui-multi-checkbox-facet__option-input-wrapper">
+                <input
+                  data-transaction-name={`facet - ${label}`}
+                  id={`example_facet_${label}${getFilterValueDisplay(
+                    option.value
+                  )}`}
+                  type="checkbox"
+                  className="sui-multi-checkbox-facet__checkbox"
+                  checked={checked}
+                  onChange={() => (checked ? onRemove(value) : onSelect(value))}
+                />
+                <span className="sui-multi-checkbox-facet__input-text">
+                  {getFilterValueDisplay(option.value)}
+                </span>
+              </div>
+              <span className="sui-multi-checkbox-facet__option-count">
+                {option.count.toLocaleString("en")}
+              </span>
+            </label>
+          );
+        })}
+      </div>
+
+      {showMore && (
+        <button
+          type="button"
+          className="sui-facet-view-more"
+          onClick={onMoreClick}
+          aria-label="Show more options"
+        >
+          + More
+        </button>
+      )}
+    </fieldset>
+  );
+}
+
+export default CustomMultiCheckboxFacet;

--- a/src/config/mapping.json
+++ b/src/config/mapping.json
@@ -1,10 +1,10 @@
 {
-    "labels": {
-        "https://bitcointalk.org": "bitcointalk",
-        "https://bitcoin.stackexchange.com": "Bitcoin StackExchange",
-        "https://lists.linuxfoundation.org/pipermail/bitcoin-dev/": "Bitcoin dev mailing list",
-        "https://lists.linuxfoundation.org/pipermail/lightning-dev/": "Lightning dev mailing list",
-        "https://btctranscripts.com/": "BTC transcripts",
-        "https://bitcoinops.org/en/": "Bitcoin Optech"
-    }
+  "labels": {
+    "https://bitcointalk.org": "bitcointalk",
+    "https://bitcoin.stackexchange.com": "Bitcoin StackExchange",
+    "https://lists.linuxfoundation.org/pipermail/bitcoin-dev/": "Bitcoin dev mailing list",
+    "https://lists.linuxfoundation.org/pipermail/lightning-dev/": "Lightning dev mailing list",
+    "https://btctranscripts.com/": "BTC transcripts",
+    "https://bitcoinops.org/en/": "Bitcoin Optech"
+  }
 }

--- a/src/config/mapping.json
+++ b/src/config/mapping.json
@@ -1,0 +1,10 @@
+{
+    "labels": {
+        "https://bitcointalk.org": "bitcointalk",
+        "https://bitcoin.stackexchange.com": "Bitcoin StackExchange",
+        "https://lists.linuxfoundation.org/pipermail/bitcoin-dev/": "Bitcoin dev mailing list",
+        "https://lists.linuxfoundation.org/pipermail/lightning-dev/": "Lightning dev mailing list",
+        "https://btctranscripts.com/": "BTC transcripts",
+        "https://bitcoinops.org/en/": "Bitcoin Optech"
+    }
+}


### PR DESCRIPTION
I cloned elastic search MultiCheckbox facet and modified the getFilterValueDisplay Function. mapping.json maps the links to their respective custom names. 

A better approach would be if both name and value came from the backend. Until then, this remains a viable option.